### PR TITLE
Cleans up bot output.

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -55,7 +55,7 @@ class RustBot(commands.Bot):
         print("Logged in as", self.user)
         print("------")
 
-        await self.change_presence(activity=discord.Game(name="??help"))
+        await self.change_presence(activity=discord.Game(name="?help"))
         self.emoji_rustok = discord.utils.get(self.emojis, name="rustOk")
         if self.emoji_rustok:
             log.info("Emoji rustOk loaded!")

--- a/bot/cogs/meta.py
+++ b/bot/cogs/meta.py
@@ -62,6 +62,12 @@ class Meta:
         deleted = await ctx.channel.purge(limit=limit, check=is_me)
         await ctx.send(f"Deleted {len(deleted)} message(s)", delete_after=5)
 
+    @commands.command()
+    async def source(self, ctx: commands.Context):
+        """Links to the bot GitHub repo."""
+
+        await ctx.send("https://github.com/ivandardi/RustbotPython")
+
     async def __after_invoke(self, ctx: commands.Context):
         await ctx.message.add_reaction(self.bot.emoji_rustok)
 


### PR DESCRIPTION
- `?eval` now removes trailing comments
- `?play` no longer displays stderr if only warnings are present
- `stderr` now also includes any `stdout` output
- Adds `?playwarn` to mimic the original `?play` behavior
- `?play` replaces Discord markdown breaking \``` with unicode grave accents in output
- Empty output now displays a blank code block instead of ```rs```