### PR TITLE
Use 2018 edition for playground command

### DIFF
--- a/bot/cogs/playground.py
+++ b/bot/cogs/playground.py
@@ -104,6 +104,7 @@ class Playground:
             payload = json.dumps(
                 {
                     "channel": "nightly",
+                    "edition": "2018",
                     "code": source,
                     "crateType": "bin",
                     "mode": mode if mode is not None else "debug",


### PR DESCRIPTION
A small change that defaults the `?play` and `?eval` commands to use Rust's 2018 edition, matching the current default setting on https://play.rust-lang.org