### PR TITLE
Add ?invite command

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -44,6 +44,7 @@ class RustBot(commands.Bot):
         ]
         self.emoji_rustok = None
         self.log = log
+        self.invite_message = os.environ.get("INVITE_DISCORD", None)
 
         for extension in self.initial_extensions:
             try:
@@ -61,6 +62,11 @@ class RustBot(commands.Bot):
             log.info("Emoji rustOk loaded!")
         else:
             log.info("Emoji rustOk not loaded! D:")
+
+        if self.invite_message is None:
+            log.info("No invite message was provided.")
+        else:
+            log.info("Thanks for the invite message c:")
 
     async def on_command(self, ctx):
         if isinstance(ctx.channel, discord.abc.PrivateChannel):

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -44,7 +44,6 @@ class RustBot(commands.Bot):
         ]
         self.emoji_rustok = None
         self.log = log
-        self.invite_message = os.environ.get("INVITE_DISCORD", None)
 
         for extension in self.initial_extensions:
             try:
@@ -62,11 +61,6 @@ class RustBot(commands.Bot):
             log.info("Emoji rustOk loaded!")
         else:
             log.info("Emoji rustOk not loaded! D:")
-
-        if self.invite_message is None:
-            log.info("No invite message was provided.")
-        else:
-            log.info("Thanks for the invite message c:")
 
     async def on_command(self, ctx):
         if isinstance(ctx.channel, discord.abc.PrivateChannel):

--- a/bot/cogs/meta.py
+++ b/bot/cogs/meta.py
@@ -45,6 +45,18 @@ class Meta:
             )
         )
 
+    @commands.command()
+    async def invite(self, ctx: commands.Context):
+        """Replies with an invite message, e.g. invite URL.
+        If a message was not provided during the bot's init,
+        direct the user to the #informational channel.
+        """
+
+        if self.bot.invite_message is not None:
+            await ctx.send(self.bot.invite_message)
+        else:
+            await ctx.send("<#273547351929520129>")
+
     @commands.command(aliases=["wustify"])
     @commands.guild_only()
     async def rustify(self, ctx: commands.Context, *members: discord.Member):

--- a/bot/cogs/meta.py
+++ b/bot/cogs/meta.py
@@ -47,15 +47,13 @@ class Meta:
 
     @commands.command()
     async def invite(self, ctx: commands.Context):
-        """Replies with an invite message, e.g. invite URL.
-        If a message was not provided during the bot's init,
-        direct the user to the #informational channel.
+        """Points the user to the #informational channel,
+        which contains invite links.
         """
 
-        if self.bot.invite_message is not None:
-            await ctx.send(self.bot.invite_message)
-        else:
-            await ctx.send("<#273547351929520129>")
+        channel = "<#273547351929520129>"
+        link = "https://discordapp.com/channels/273534239310479360/273547351929520129/288101969980162049"
+        await ctx.send(f"Invite links are provided in {channel}\n{link}")
 
     @commands.command(aliases=["wustify"])
     @commands.guild_only()


### PR DESCRIPTION
~~The message is provided by the environment variable `INVITE_DISCORD` and is intended to be an invite link, but anything else could be included in the string. If the variable was not found during the bot's initialization, the command defaults to directing the user to the `#informational` channel.~~

`?invite` points to the `#informational` channel. Includes a direct link to the message.