### PR TITLE
Edit playground responses when input edited

### DIFF
--- a/bot/cogs/playground.py
+++ b/bot/cogs/playground.py
@@ -55,6 +55,7 @@ class Playground(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
         self.session = aiohttp.ClientSession(loop=self.bot.loop)
+        self.sent_evals = {}
 
     def cog_unload(self):
         self.bot.loop.create_task(self.session.close())
@@ -63,13 +64,13 @@ class Playground(commands.Cog):
     async def play(self, ctx: commands.Context, *, arg):
         """Evaluates Rust code. Exactly equal to https://play.rust-lang.org/"""
         (mode, code) = self.parse_args(arg)
-        await self.query_playground(ctx, mode, code.source)
+        await self.send_playground(ctx, mode, code.source)
 
     @commands.command()
     async def playwarn(self, ctx: commands.Context, *, arg):
         """Evaluates Rust code and outputs generated warnings. Exactly equal to https://play.rust-lang.org/"""
         (mode, code) = self.parse_args(arg)
-        await self.query_playground(ctx, mode, code.source, warnings=True)
+        await self.send_playground(ctx, mode, code.source, warnings=True)
 
     @commands.command()
     async def eval(self, ctx: commands.Context, *, arg):
@@ -77,7 +78,7 @@ class Playground(commands.Cog):
         (mode, code) = self.parse_args(arg)
         comment_index = code.source.find("//")
         end_idx = comment_index if comment_index != -1 else len(code.source)
-        await self.query_playground(
+        await self.send_playground(
             ctx, mode, 'fn main(){println!("{:?}",{' + code.source[:end_idx] + "});}"
         )
 
@@ -85,6 +86,34 @@ class Playground(commands.Cog):
     async def go(self, ctx: commands.Context):
         """Evaluates Go code"""
         await ctx.send("No")
+
+    @commands.Cog.listener()
+    async def on_message_edit(self, before, after):
+        sent_eval_id = self.sent_evals.get(before.id, None)
+        if sent_eval_id is not None:
+            ctx: commands.Context = await self.bot.get_context(after)
+            if not ctx.valid:
+                return
+
+            sent_eval = await ctx.fetch_message(sent_eval_id)
+
+            await ctx.command.prepare(ctx)
+
+            # 'arg' depends on the name of the argument in the commands above; they must all at least be the same, and
+            # if they change, this must be changed too. Messy, but arguments are only provided as a dict.
+            (mode, code) = self.parse_args(ctx.kwargs['arg'])
+
+            warnings = False
+            if ctx.command.name == "eval":
+                comment_index = code.source.find("//")
+                end_idx = comment_index if comment_index != -1 else len(code.source)
+                code.source = 'fn main(){println!("{:?}",{' + code.source[:end_idx] + "});}"
+            elif ctx.command.name == "playwarn":
+                warnings = True
+            elif ctx.command.name != "play":
+                return
+
+            await self.edit_playground(ctx, sent_eval, mode, code.source, warnings)
 
     def parse_args(self, args):
         args = args.replace("\n`", " `").split(" ")
@@ -102,53 +131,63 @@ class Playground(commands.Cog):
             code = " ".join(args[0:])
             return None, CodeSection(code)
 
-    async def query_playground(
-            self, ctx: commands.Context, mode, code, warnings: bool = False
-    ):
+    async def edit_playground(self, ctx: commands.Context, sent_message, mode, code, warnings: bool = False):
         async with ctx.typing():
-            payload = json.dumps(
-                {
-                    "channel": "nightly",
-                    "edition": "2018",
-                    "code": code,
-                    "crateType": "bin",
-                    "mode": mode if mode is not None else "debug",
-                    "tests": False,
-                }
-            )
+            await sent_message.edit(content=await self.query_playground(mode, code, warnings))
 
-            async with self.session.post(
-                    "https://play.rust-lang.org/execute", data=payload
-            ) as r:
-                if r.status != 200:
-                    raise commands.CommandError(
-                        "Rust Playground didn't respond in time. :("
-                    )
+    async def send_playground(self, ctx: commands.Context, mode, code, warnings: bool = False):
+        async with ctx.typing():
+            sent_message = await ctx.send(await self.query_playground(mode, code, warnings))
 
-                response = await r.json()
-                if "error" in response:
-                    raise commands.CommandError(response["error"])
+        self.sent_evals[ctx.message.id] = sent_message.id
 
-                stderr = response["stderr"]
-                stdout = response["stdout"]
+    async def query_playground(
+            self, mode, code, warnings: bool = False
+    ):
+        payload = json.dumps(
+            {
+                "channel": "nightly",
+                "edition": "2018",
+                "code": code,
+                "crateType": "bin",
+                "mode": mode if mode is not None else "debug",
+                "tests": False,
+            }
+        )
 
-                full_response = (
-                    stdout
-                    if err_regex.search(stderr) is None
-                       and not (warnings and len(stderr) >= 4)
-                       and "panicked" not in stderr
-                    else "\n".join(stderr.split("\n")[1:]) + "\n\n" + stdout
+        async with self.session.post(
+                "https://play.rust-lang.org/execute", data=payload
+        ) as r:
+            if r.status != 200:
+                raise commands.CommandError(
+                    "Rust Playground didn't respond in time. :("
                 )
-                len_response = len(full_response)
-                if len_response == 0:
-                    msg = "``` ```"
-                elif len_response < 1990:
-                    full_response = full_response.replace("```", "  ̀  ̀  ̀")
-                    msg = f"```rs\n{full_response}```"
-                else:
-                    msg = await self.get_playground_link(code)
 
-                await ctx.send(msg)
+            response = await r.json()
+            if "error" in response:
+                raise commands.CommandError(response["error"])
+
+            stderr = response["stderr"]
+            stdout = response["stdout"]
+
+            full_response = (
+                stdout
+                if err_regex.search(stderr) is None
+                   and not (warnings and len(stderr) >= 4)
+                   and "panicked" not in stderr
+                else "\n".join(stderr.split("\n")[1:]) + "\n\n" + stdout
+            )
+            len_response = len(full_response)
+            if len_response == 0:
+                msg = "``` ```"
+            elif len_response < 1990:
+                full_response = full_response.replace("```", "  ̀  ̀  ̀")
+                msg = f"```rs\n{full_response}```"
+            else:
+                msg = await self.get_playground_link(code)
+
+            return msg
+
 
     async def get_playground_link(self, code):
         headers = {

--- a/bot/cogs/playground.py
+++ b/bot/cogs/playground.py
@@ -115,6 +115,10 @@ class Playground(commands.Cog):
 
             await self.edit_playground(ctx, sent_eval, mode, code.source, warnings)
 
+    @commands.Cog.listener()
+    async def on_message_delete(self, message):
+        self.sent_evals.pop(message.id, None)
+
     def parse_args(self, args):
         args = args.replace("\n`", " `").split(" ")
         if args[0].startswith("--"):


### PR DESCRIPTION
This makes ferris edit responses to ?play, ?playwarn, and ?eval when the input message was edited. This allows for easy fixing of accidental errors and changing play to playwarn.